### PR TITLE
Bumped ubuntu to 18.04 and python to 3.7

### DIFF
--- a/orbyter-base-sys-dl/2.0/Dockerfile
+++ b/orbyter-base-sys-dl/2.0/Dockerfile
@@ -1,0 +1,28 @@
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
+# This part below should be same as in orbyter-base-sys/2.x/Dockerfile
+COPY . /build
+WORKDIR /build
+ENV LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8
+RUN apt-get update -qq && \
+    apt-get install -qqy --no-install-recommends \
+      vim \
+      emacs \
+      screen \
+      git \
+      wget \
+      curl \
+      build-essential \
+      cmake \
+      htop \
+      python3.7 \
+      python3-pip && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -f /usr/bin/python3 && \
+    rm -f /usr/bin/python && \
+    ln -s /usr/bin/python3.7 /usr/bin/python3 && \
+    ln -s /usr/bin/python3.7 /usr/bin/python && \
+    ln -s /usr/bin/pip3 /usr/bin/pip && \
+    rm -rf ~/.cache
+WORKDIR /
+RUN rm -rf /build

--- a/orbyter-base-sys-dl/2.0/README.md
+++ b/orbyter-base-sys-dl/2.0/README.md
@@ -1,0 +1,10 @@
+# 
+This is the Dockerfile for manifoldai/orbyter-base-sys-dl:1.1
+
+Release Notes:
+This is similar to manifoldai/orbyter-base-sys,  but uses nvidia cuda 10.0 image as the base image.
+
+General development tools: vim,  emacs,  git,  screen,  wget
+Python: 3.7
+OS: Ubuntu 18.04
+For a complete list, see the Dockerfile in this directory.

--- a/orbyter-base-sys/2.0/Dockerfile
+++ b/orbyter-base-sys/2.0/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:18.04
+# This part below should be same as in orbyter-base-sys-dl/1.x/Dockerfile
+COPY . /build
+WORKDIR /build
+ENV LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8
+RUN apt-get update -qq && \
+    apt-get install -qqy --no-install-recommends \
+      vim \
+      emacs \
+      screen \
+      git \
+      wget \
+      curl \
+      build-essential \
+      cmake \
+      htop \
+      python3.7 \
+      python3-pip && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -f /usr/bin/python3 && \
+    rm -f /usr/bin/python && \
+    ln -s /usr/bin/python3.7 /usr/bin/python3 && \
+    ln -s /usr/bin/python3.7 /usr/bin/python && \
+    ln -s /usr/bin/pip3 /usr/bin/pip && \
+    rm -rf ~/.cache
+WORKDIR /
+RUN rm -rf /build

--- a/orbyter-base-sys/2.0/README.md
+++ b/orbyter-base-sys/2.0/README.md
@@ -1,0 +1,8 @@
+# 
+This is the Dockerfile for manifoldai/orbyter-base-sys:2.0
+
+Release Notes:
+General development tools: vim,  emacs,  git,  screen,  wget
+Python: 3.7
+OS: Ubuntu 18.04
+For a complete list, see the Dockerfile in this directory.


### PR DESCRIPTION
# Changes
* Added base-sys:2.0
* Added base-sys-dl:2.0
* Removed some unused python packages:  python3.6-dev, python3.6-venv, python3.6-tk

In these images, I've bumped ubuntu to 18.04 and python to 3.7.  

Raj, can you review? I included Sourav as a reviewer to keep him updated.