### PR TITLE
upgrade dl-dev to 3.2

### DIFF
--- a/orbyter-dl-dev/requirements.txt
+++ b/orbyter-dl-dev/requirements.txt
@@ -8,8 +8,6 @@ dask[complete]==2021.1.1
 dask-ml==1.7.0
 dlib==19.21.1
 dvc==1.11.13
-fastai==2.2.5
-Keras==2.3.0
 fire==0.4.0
 flake8==3.8.4
 ipdb==0.13.4
@@ -41,7 +39,6 @@ Sphinx==3.4.3
 statsmodels==0.12.1
 streamlit==0.75.0
 SQLAlchemy==1.3.22
-tensorflow==2.4.1
 torch==1.7.1
 xarray==0.16.2
 xgboost==1.3.3


### PR DESCRIPTION
Upgrade dl-dev from 2.0 to 3.2. Upgrades include

* changing the base image from orbyter-base-sys-dl:2.0 to orbyter-base-sys-dl:3.2
* Updating dependencies
* Adding dependencies dvc + jupyterlab
* Slim down dl-dev by getting rid of deep learning libraries rarely used.