### PR TITLE
fix: roll back mypy to version 0.812 to avoid breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# manifold/orbyter-docker 
+# manifold/orbyter-docker
 
 Manifold's Orbyter docker image toolset helps Data Science teams easily move to a
 container-first workflow, from local development to serving in production settings. The
@@ -11,6 +11,7 @@ below.
 ## General structure
 
 Each docker image (dockerhub repo) has a folder with the following file structure:
+
 ```
 docker-repo/ # e.g, docker-ml-dev
 ├── Dockerfile
@@ -26,24 +27,24 @@ reference the image by its git tag.
 ## Tagging
 
 Each given image release is marked by a git tag. The tagging convention is
-`<repo-name>-<version>`. For example, the git tag `tag:orbyter-ml-dev:3.3` corresponds to
-version `3.3` of the image `orbyter-ml-dev`. Pushing a tag to github will trigger a deployment of
+`<repo-name>-<version>`. For example, the git tag `tag:orbyter-ml-dev:3.5` corresponds to
+version `3.5` of the image `orbyter-ml-dev`. Pushing a tag to github will trigger a deployment of
 that image to docker hub.
 
 ## Image release steps
 
 We'll describe how to release a new `orbyter-ml-dev`, but the steps are the same for other images.
-Let's say we are releasing version `3.3` of `orbyter-ml-dev`.
+Let's say we are releasing version `3.5` of `orbyter-ml-dev`.
 
-1. Create a new branch, e.g, `mws/orbyter-ml-dev-3.3`
+1. Create a new branch, e.g, `mws/orbyter-ml-dev-3.5`
 2. Make changes in `orbyter-ml-dev/`: `Dockerfile`, `requirements.txt`, `README.md`, and bump `VERSION` to
-   `3.3`. Note, you can test your new build by running `make build-ml-dev` from the top-level directory
+   `3.5`. Note, you can test your new build by running `make build-ml-dev` from the top-level directory
 3. Create a pull request back into master.
 4. When changes are merged to `master`, get the latest commit: `git checkout master`,
    `git pull`
 5. Tag the code: `make release-ml-dev`. This will push the tag to origin and
    kick-off a GitHub actions job that will push two new images to
-   `manifoldai/orbyter-ml-dev:3.3` and `manifoldai/orbyter-ml-dev:latest`.
+   `manifoldai/orbyter-ml-dev:3.5` and `manifoldai/orbyter-ml-dev:latest`.
 
 ## Docker images
 
@@ -54,7 +55,6 @@ of this, and this should not be used directly for development. This base image c
 basic tools like vim, emacs, curl, and python, but does not install any ML specific
 packages.
 
-
 ### orbyter-base-sys-dl
 
 Base docker image for deep learning development in python, which contains CUDA
@@ -62,7 +62,6 @@ libraries. DL images are build on top of this, and this should not be used direc
 development. This base image, like orbyte-base-sys, contains basic tools like vim,
 emacs, curl, and python. Because it contains the CUDA libraries, it is compatible with
 many deep learning frameworks like pytorch.
-
 
 ### orbyter-ml-dev
 
@@ -77,11 +76,10 @@ Docker image for deep learning development.
 
 Docker image for ML projects with Apache Spark.
 
-
 ## Historical notes
 
 After commit `e039c36`, this repo was drastically reorganized. `<=e039c36`, each version
-of each docker repositories image was given as a subfolder. E.g, 
+of each docker repositories image was given as a subfolder. E.g,
 
 ```
 orbyter-ml-dev/
@@ -100,4 +98,3 @@ While this structure provided nice auditability, it did not lend itself to conti
 deployment of new images, didn't scale well, and was challenging to code review.
 Therefore, after commit `>e039c36`, we organized to only contain the latest version of
 each docker repo.
-

--- a/orbyter-ml-dev/README.md
+++ b/orbyter-ml-dev/README.md
@@ -44,7 +44,7 @@ System:
 - matplotlib==3.4.2
 - mlflow==1.17.0
 - more-itertools==8.8.0
-- mypy==0.902
+- mypy==0.812
 - notebook==6.4.0
 - numpy==1.20.3
 - pandas==1.2.4
@@ -69,7 +69,19 @@ System:
 
 ## Release Notes:
 
-### 3.5
+### 3.5.1
+
+The `orbyter-ml-dev:3.5` tag will point to this patched version.
+
+Roll back to `mypy==0.812` to avoid breaking changes made to how certain third party types are defined, which caused CI to fail for 3.5.0 images without additional packages.
+
+#### Python package updates
+
+##### Updated
+
+- mypy==0.812
+
+### 3.5.0
 
 Updated `jupyterlab==3.0.16` and others, added `dask-cloudprovider==2021.3.1` and `dask-labextension==5.0.2` for distributed computing, and `aquirdturtle-collapsible-headers==3.1.0` Jupyterlab extension for Jupyter notebook style folding of headers.
 

--- a/orbyter-ml-dev/requirements.txt
+++ b/orbyter-ml-dev/requirements.txt
@@ -22,7 +22,7 @@ line-profiler==3.3.0
 matplotlib==3.4.2
 mlflow==1.17.0
 more-itertools==8.8.0
-mypy==0.902
+mypy==0.812
 notebook==6.4.0
 numpy==1.20.3
 pandas==1.2.4


### PR DESCRIPTION
# Context:

The latest version of `mypy` 0.9+ recently introduced breaking changes to how they define types for common third-party packages, such as `requests` and `PyYAML`. Namely, they no longer bundle type definitions of these libraries with their package and instead require an additional type-definitions package to be installed for each third party library. Unfortunately, instead of ignoring those libraries with the `--ignore-missing-imports` flag, they actually require the packages to be installed if they used to support the package in versions <0.9, or they will raise an error. This disrupts our current CI pipeline, so I'm rolling back to `0.812` for now.

# Changes:
* Update `mypy` package to `mypy==0.812`
* Version 3.5 stays the same in `VERSION`, so that 3.5 points to the latest patched image in Docker Hub

# Tests:
This docker image successfully runs the CI pipeline defined in our orbyter cookiecutter.