### PR TITLE
Added visualization packages for dask DAGs

### DIFF
--- a/orbyter-ml-dev/Dockerfile
+++ b/orbyter-ml-dev/Dockerfile
@@ -4,6 +4,7 @@ COPY . /build
 WORKDIR /build
 RUN apt-get update && \
     apt-get install -y libpq-dev && \
+    apt-get install -y graphviz && \
     pip install -r requirements.txt && \
     jupyter contrib nbextension install --user && \
     jupyter nbextension enable --py widgetsnbextension && \

--- a/orbyter-ml-dev/README.md
+++ b/orbyter-ml-dev/README.md
@@ -33,6 +33,7 @@ System:
 - dask-ml==1.9.0
 - dvc==2.4.1
 - flake8==3.9.2
+- graphviz==0.16
 - ipdb==0.13.9
 - ipython==7.24.1
 - isort==5.8.0
@@ -61,6 +62,7 @@ System:
 - scipy==1.6.3
 - seaborn==0.11.1
 - shap==0.39.0
+- snakeviz==2.1.0
 - Sphinx==4.0.2
 - SQLAlchemy==1.4.18
 - statsmodels==0.12.2
@@ -70,6 +72,11 @@ System:
 - xgboost==1.4.2
 
 ## Release Notes:
+### 3.5.3
+
+The `orbyter-ml-dev:3.5` tag will point to this patched version.
+
+Added graphviz system library. Added graphviz and snakeviz python packages
 
 ### 3.5.2
 

--- a/orbyter-ml-dev/requirements.txt
+++ b/orbyter-ml-dev/requirements.txt
@@ -11,6 +11,7 @@ dask-labextension==5.0.2
 dask-ml==1.9.0
 dvc==2.4.1
 flake8==3.9.2
+graphviz==0.16
 ipdb==0.13.9
 ipython==7.24.1
 isort==5.8.0
@@ -39,6 +40,7 @@ scikit-learn==0.24.2
 scipy==1.6.3
 seaborn==0.11.1
 shap==0.39.0
+snakeviz==2.1.0
 Sphinx==4.0.2
 SQLAlchemy==1.4.18
 statsmodels==0.12.2


### PR DESCRIPTION
Added graphviz system lib.
Added graphviz and snakeviz python libs. 
These are necessary for visualizing Dask DAGs for the tutorial. 