### PR TITLE
security: bump jupyterlab version to 3.0.17 for security patch

### DIFF
--- a/orbyter-dl-dev/README.md
+++ b/orbyter-dl-dev/README.md
@@ -6,13 +6,19 @@ Dockerfile for [manifoldai/orbyter-dl-dev:3.2](https://hub.docker.com/r/manifold
 
 To run a bash shell
 
-`
-docker run -it manifoldai/orbyter-dl-dev:3.2 bash
-`
+`docker run -it manifoldai/orbyter-dl-dev:3.2 bash`
 
 ## Release Notes:
 
-Now using `orbyter-base-sys-dl:3.2` as a base image. 
+### 3.2.1
+
+The `orbyter-dl-dev:3.2` tag will point to this patched version.
+
+Updates `jupyterlab` to 3.0.17 for security patch.
+
+### 3.2
+
+Now using `orbyter-base-sys-dl:3.2` as a base image.
 
 ### Python package updates
 
@@ -20,50 +26,50 @@ Now using `orbyter-base-sys-dl:3.2` as a base image.
 
 #### Updated
 
-* bayesian-optimization==1.2.0
-* black==19.3b0
-* bokeh==2.2.3
-* boto3==1.16.60
-* Click==7.1.2
-* coloredlogs==15.0
-* dask[complete]==2021.1.1
-* dask-ml==1.7.0
-* dlib==19.21.1
-* fastai==2.2.5
-* Keras==2.3.0
-* fire==0.4.0
-* flake8==3.8.4
-* ipdb==0.13.4
-* isort==5.7.0
-* jsonlines==2.0.0
-* jupyter==1.0.0
-* jupyter-contrib-nbextensions==0.5.1
-* lightgbm==3.1.1
-* matplotlib==3.3.3
-* mlflow==1.13.1
-* more-itertools==8.6.0
-* notebook==6.2.0
-* numpy==1.19.5
-* pandas==1.2.1
-* plotly==4.14.3
-* pluggy==0.13.1
-* psycopg2==2.8.6
-* pyarrow==3.0.0
-* pytest==6.2.2
-* python-dotenv==0.15.0
-* pytictoc==1.5.1
-* scikit-learn==0.24.1
-* scipy==1.6.0
-* seaborn==0.11.1
-* shap==0.38.1
-* Sphinx==3.4.3
-* statsmodels==0.12.1
-* streamlit==0.75.0
-* SQLAlchemy==1.3.22
-* tensorflow==2.4.1
-* torch==1.7.1
-* xarray==0.16.2
-* xgboost==1.3.3
+- bayesian-optimization==1.2.0
+- black==19.3b0
+- bokeh==2.2.3
+- boto3==1.16.60
+- Click==7.1.2
+- coloredlogs==15.0
+- dask[complete]==2021.1.1
+- dask-ml==1.7.0
+- dlib==19.21.1
+- fastai==2.2.5
+- Keras==2.3.0
+- fire==0.4.0
+- flake8==3.8.4
+- ipdb==0.13.4
+- isort==5.7.0
+- jsonlines==2.0.0
+- jupyter==1.0.0
+- jupyter-contrib-nbextensions==0.5.1
+- lightgbm==3.1.1
+- matplotlib==3.3.3
+- mlflow==1.13.1
+- more-itertools==8.6.0
+- notebook==6.2.0
+- numpy==1.19.5
+- pandas==1.2.1
+- plotly==4.14.3
+- pluggy==0.13.1
+- psycopg2==2.8.6
+- pyarrow==3.0.0
+- pytest==6.2.2
+- python-dotenv==0.15.0
+- pytictoc==1.5.1
+- scikit-learn==0.24.1
+- scipy==1.6.0
+- seaborn==0.11.1
+- shap==0.38.1
+- Sphinx==3.4.3
+- statsmodels==0.12.1
+- streamlit==0.75.0
+- SQLAlchemy==1.3.22
+- tensorflow==2.4.1
+- torch==1.7.1
+- xarray==0.16.2
+- xgboost==1.3.3
 
 #### Added
 
@@ -77,55 +83,54 @@ the useful packages for ML development.
 
 System:
 
-* Ubuntu 20.04 LTS
-* Python 3.8.5
+- Ubuntu 20.04 LTS
+- Python 3.8.5
 
 ## Included Packages :
 
-* bayesian-optimization==1.2.0
-* black==19.3b0
-* bokeh==2.2.3
-* boto3==1.16.60
-* Click==7.1.2
-* coloredlogs==15.0
-* dask[complete]==2021.1.1
-* dask-ml==1.7.0
-* dlib==19.21.1
-* dvc==1.11.13
-* fastai==2.2.5
-* Keras==2.3.0
-* fire==0.4.0
-* flake8==3.8.4
-* ipdb==0.13.4
-* isort==5.7.0
-* jsonlines==2.0.0
-* jupyter==1.0.0
-* jupyter-contrib-nbextensions==0.5.1
-* jupyterlab==3.0.5
-* lightgbm==3.1.1
-* matplotlib==3.3.3
-* mlflow==1.13.1
-* more-itertools==8.6.0
-* notebook==6.2.0
-* numpy==1.19.5
-* pandas==1.2.1
-* plotly==4.14.3
-* pluggy==0.13.1
-* psycopg2==2.8.6
-* pyarrow==3.0.0
-* pytest==6.2.2
-* python-dotenv==0.15.0
-* pytictoc==1.5.1
-* scikit-learn==0.24.1
-* scipy==1.6.0
-* seaborn==0.11.1
-* shap==0.38.1
-* Sphinx==3.4.3
-* statsmodels==0.12.1
-* streamlit==0.75.0
-* SQLAlchemy==1.3.22
-* tensorflow==2.4.1
-* torch==1.7.1
-* xarray==0.16.2
-* xgboost==1.3.3
-
+- bayesian-optimization==1.2.0
+- black==19.3b0
+- bokeh==2.2.3
+- boto3==1.16.60
+- Click==7.1.2
+- coloredlogs==15.0
+- dask[complete]==2021.1.1
+- dask-ml==1.7.0
+- dlib==19.21.1
+- dvc==1.11.13
+- fastai==2.2.5
+- Keras==2.3.0
+- fire==0.4.0
+- flake8==3.8.4
+- ipdb==0.13.4
+- isort==5.7.0
+- jsonlines==2.0.0
+- jupyter==1.0.0
+- jupyter-contrib-nbextensions==0.5.1
+- jupyterlab==3.0.5
+- lightgbm==3.1.1
+- matplotlib==3.3.3
+- mlflow==1.13.1
+- more-itertools==8.6.0
+- notebook==6.2.0
+- numpy==1.19.5
+- pandas==1.2.1
+- plotly==4.14.3
+- pluggy==0.13.1
+- psycopg2==2.8.6
+- pyarrow==3.0.0
+- pytest==6.2.2
+- python-dotenv==0.15.0
+- pytictoc==1.5.1
+- scikit-learn==0.24.1
+- scipy==1.6.0
+- seaborn==0.11.1
+- shap==0.38.1
+- Sphinx==3.4.3
+- statsmodels==0.12.1
+- streamlit==0.75.0
+- SQLAlchemy==1.3.22
+- tensorflow==2.4.1
+- torch==1.7.1
+- xarray==0.16.2
+- xgboost==1.3.3

--- a/orbyter-dl-dev/requirements.txt
+++ b/orbyter-dl-dev/requirements.txt
@@ -16,7 +16,7 @@ isort==5.7.0
 jsonlines==2.0.0
 jupyter==1.0.0
 jupyter-contrib-nbextensions==0.5.1
-jupyterlab==3.0.7
+jupyterlab==3.0.17
 lightgbm==3.1.1
 matplotlib==3.3.3
 mlflow==1.13.1

--- a/orbyter-ml-dev/README.md
+++ b/orbyter-ml-dev/README.md
@@ -40,7 +40,7 @@ System:
 - jsonlines==2.0.0
 - jupyter==1.0.0
 - jupyter-contrib-nbextensions==0.5.1
-- jupyterlab==3.0.16
+- jupyterlab==3.0.17
 - lightgbm==3.2.1
 - line-profiler==3.3.0
 - matplotlib==3.4.2
@@ -72,15 +72,18 @@ System:
 - xgboost==1.4.2
 
 ## Release Notes:
-### 3.5.3
+
+### 3.5.4
 
 The `orbyter-ml-dev:3.5` tag will point to this patched version.
+
+Updates `jupyterlab` to 3.0.17 for security patch.
+
+### 3.5.3
 
 Added graphviz system library. Added graphviz and snakeviz python packages
 
 ### 3.5.2
-
-The `orbyter-ml-dev:3.5` tag will point to this patched version.
 
 Updated `dask-cloudprovider` package to include the AWS subpackage and added the `s3fs` and `awscli` packages for better integration with AWS services. Updated `dvc==2.4.1` and reverted back to `boto3==1.17.49` for package compatibility reasons.
 

--- a/orbyter-ml-dev/requirements.txt
+++ b/orbyter-ml-dev/requirements.txt
@@ -18,7 +18,7 @@ isort==5.8.0
 jsonlines==2.0.0
 jupyter==1.0.0
 jupyter-contrib-nbextensions==0.5.1
-jupyterlab==3.0.16
+jupyterlab==3.0.17
 lightgbm==3.2.1
 line-profiler==3.3.0
 matplotlib==3.4.2

--- a/orbyter-spark-dev/README.md
+++ b/orbyter-spark-dev/README.md
@@ -6,9 +6,7 @@ Dockerfile for [manifoldai/orbyter-spark-dev:0.1](https://hub.docker.com/r/manif
 
 To run a bash shell
 
-`
-docker run -it manifoldai/orbyter-spark-dev:3.3 bash
-`
+`docker run -it manifoldai/orbyter-spark-dev:0.1 bash`
 
 ## Image overview
 
@@ -17,15 +15,19 @@ the useful packages for ML development, see [requirements.txt].
 
 System:
 
-* Ubuntu 20.04 LTS
-* Python 3.8.5
-* Spark 3.1.1
-* Hadoop 2.7
-
+- Ubuntu 20.04 LTS
+- Python 3.8.5
+- Spark 3.1.1
+- Hadoop 2.7
 
 ## Release Notes:
+
+### 0.1.1
+
+The `orbyter-spark-dev:0.1` image will point to this release.
+
+Updates `jupyterlab` to 3.0.17 for security patch.
 
 ### 0.1
 
 Initial release.
-

--- a/orbyter-spark-dev/requirements.txt
+++ b/orbyter-spark-dev/requirements.txt
@@ -13,7 +13,7 @@ isort==5.7.0
 jsonlines==2.0.0
 jupyter==1.0.0
 jupyter-contrib-nbextensions==0.5.1
-jupyterlab==3.0.7
+jupyterlab==3.0.17
 lightgbm==3.1.1
 matplotlib==3.3.4
 mlflow==1.13.1


### PR DESCRIPTION
# Context
This addresses the recent security advisory: "JupyterLab: XSS due to lack of sanitization of the action attribute of an html <form>"

## Changes
* bump `jupyterlab` to version 3.0.17 in `orbyter-ml-dev`, `orbyter-dl-dev`, and `orbyter-spark-dev`