### PR TITLE
fix: platforms must be set in build-push-action step

### DIFF
--- a/.github/workflows/base-sys-tag-docker-push.yml
+++ b/.github/workflows/base-sys-tag-docker-push.yml
@@ -18,8 +18,6 @@ jobs:
         run: echo ${{ steps.get_version.outputs.VERSION }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          platforms: linux/amd64,linux/arm64
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -29,6 +27,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: orbyter-base-sys
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             manifoldai/orbyter-base-sys:latest

--- a/.github/workflows/ml-dev-tag-docker-push.yml
+++ b/.github/workflows/ml-dev-tag-docker-push.yml
@@ -18,8 +18,6 @@ jobs:
         run: echo ${{ steps.get_version.outputs.VERSION }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          platforms: linux/amd64,linux/arm64
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -29,6 +27,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: orbyter-ml-dev
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             manifoldai/orbyter-ml-dev:latest

--- a/.github/workflows/spark-dev-tag-docker-push.yml
+++ b/.github/workflows/spark-dev-tag-docker-push.yml
@@ -27,6 +27,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: orbyter-spark-dev
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             manifoldai/orbyter-spark-dev:latest


### PR DESCRIPTION
Previous PR tried to setup a multiplatform stage by configuring `buildx`. I think `buildx` is already configured for several platforms, and what we need to do is set the target platforms in the `build-push-action` step.

Also decided to try to make the spark image multiplatform.