### PR TITLE
fix: add qemu-setup-action for multiple platform builds

### DIFF
--- a/.github/workflows/base-sys-tag-docker-push.yml
+++ b/.github/workflows/base-sys-tag-docker-push.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Echo version
         id: echo_version
         run: echo ${{ steps.get_version.outputs.VERSION }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub

--- a/.github/workflows/ml-dev-tag-docker-push.yml
+++ b/.github/workflows/ml-dev-tag-docker-push.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Echo version
         id: echo_version
         run: echo ${{ steps.get_version.outputs.VERSION }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub

--- a/.github/workflows/spark-dev-tag-docker-push.yml
+++ b/.github/workflows/spark-dev-tag-docker-push.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Echo version
         id: echo_version
         run: echo ${{ steps.get_version.outputs.VERSION }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub


### PR DESCRIPTION
Following [build-push-action example code](https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md), add QEMU setup for multiplatform builds. Wasn't sure if this was needed. Apparently it is.