### PR TITLE
fix: docker build context

### DIFF
--- a/.github/workflows/tag-docker-push.yml
+++ b/.github/workflows/tag-docker-push.yml
@@ -55,7 +55,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
-          context: ${{ steps.get_version.outputs.BASE }}
+          file: ${{ steps.get_version.outputs.BASE }})/Dockerfile
+          context: .
           platforms: ${{ steps.get_version.outputs.PLATFORMS }}
           push: true
           tags: |


### PR DESCRIPTION
Update the workflow build context -- now it matches how we build in `Makefile`

We need this in order to copy shared requirements file in.